### PR TITLE
Update requirements.txt to include missing packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # test-time requirements
 matplotlib>=3.2.2
 ghapi
+pystrict
 pytest
 exdown>=0.8.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # test-time requirements
+exdown
 matplotlib>=3.2.2
 ghapi
 pystrict


### PR DESCRIPTION
When installing via the instructions `pip install git+https://github.com/atmos-cloud-sim-uj/PySDM.git` in the README from a fresh conda environment w/ Python=3.8, `pystrict` was not installed so neither the tests nor the demo code could run.