### PR TITLE
Singularity testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=['ThrustRTC==0.3.10',
                       'CURandRTC==0.1.6',
                       'numba==0.53.1',
-                      'numpy>=1.20.2',
+                      'numpy>=1.19.5',
                       'Pint>=0.17',
                       'chempy>=0.7.10',
                       'scipy>=1.6.3'],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
                       'numpy>=1.19.5',
                       'Pint>=0.17',
                       'chempy>=0.7.10',
-                      'scipy>=1.6.3'],
+                      'scipy>=1.5.4'],
     author='https://github.com/atmos-cloud-sim-uj/PySDM/graphs/contributors',
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
For some reason my pip3 cannot find the versions of numpy and scipy specified in the requirements. I tried upgrading pip3 but it did not solve the problem. 

Would it be possible to downgrade those requirements?