### PR TITLE
Conda distribution

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -18,22 +18,20 @@ requirements:
     - pip
     - python
     - setuptools_scm
-    ## Uncomment when they are available
-    ## - thrustrtc >=0.3.3
-    ## - curandrtc >=0.1.2
+    - thrustrtc
+    - curandrtc
 
   run:
     - pip
     - python
     - numpy
-    - numba >=0.51.2
+    - numba
     - pint
     - chempy
     - scipy
     - pyevtk
-    ## Uncomment when they are available
-    ## - thrustrtc >=0.3.3
-    ## - curandrtc >=0.1.2
+    - thrustrtc
+    - curandrtc
 
 about:
   home: "https://atmos-cloud-sim-uj.github.io/PySDM/"

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "pysdm" %}
+{% set version = "1.4" %}
+
+package:
+  name: "{{ name }}"
+  version: "{{ version }}"
+
+source:
+  git_url: "https://github.com/atmos-cloud-sim-uj/PySDM.git"
+  git_rev: 83649d5af8a949f355debbb8743765c520810cc7 
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - pip
+    - python
+    - setuptools_scm
+    ## Uncomment when they are available
+    ## - thrustrtc >=0.3.3
+    ## - curandrtc >=0.1.2
+
+  run:
+    - pip
+    - python
+    - numpy
+    - numba >=0.51.2
+    - pint
+    - chempy
+    - scipy
+    - pyevtk
+    ## Uncomment when they are available
+    ## - thrustrtc >=0.3.3
+    ## - curandrtc >=0.1.2
+
+about:
+  home: "https://atmos-cloud-sim-uj.github.io/PySDM/"
+  license: GPL3
+  license_family: GPL
+  summary: "Pythonic particle-based (super-droplet) warm-rain/aqueous-chemistry cloud microphysics package with box, parcel & 1D/2D prescribed-flow examples in Python, Julia and Matlab"


### PR DESCRIPTION
As per #494, PySDM should get a release for the Anaconda ecosystem. While I'm not an expert, I can at least create a barebones configuration file.

With my limited of package distribution via conda-forge, there are several issues with this at the moment:

* Since all the dependencies need to be in the Anaconda ecosystem, as @slayoo already mentioned in #494, ThrustRTC and CURandRTC do not have (recent) releases for Anaconda.
* A similar issue exists with chempy - while it does have an old Anaconda distribution, it is on a relatively unpopular channel (bjodah). This means that the install command is unintuitive, and the issue is not immediately obvious. This would not be a problem if [this issue](https://github.com/conda/conda-build/issues/532) gets resolved.

To build the Anaconda package:
```
cd PySDM
conda-build . -c conda-forge -c bjodah
# activate your virtual environment
# for example: conda activate PySDMEnvironment
conda install --use-local PySDM=1.4 -c conda-forge -c bjodah
```
As a side note, [here](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html) you can find the documentation for the meta.yaml file.