### PR TITLE
Edj/concise paper

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -245,7 +245,7 @@
 @article{DeJong_et_al_2022,
   title = {Breakups are Complicated: Representing Collisional Droplet Breakup in the Superdroplet Method},
   author = {De Jong, E. and Mackay, J. B. and Jaruga, A.},
-  year = {In preparation}
+  year = {in preparation}
 }
 
 @article{Ovadnevaite_et_al_2017,

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -55,8 +55,8 @@ affiliations:
 bibliography: paper.bib
 
 ---
+# Summary
 
-# Background and Statement of Need
 `PySDM` and the accompanying `PySDM-examples` packages are open-source modeling tools
   for computational studies of atmospheric clouds, aerosols, and precipitation. The
   project hinges on a particle-based modeling approach and Pythonic design and
@@ -65,6 +65,13 @@ The eponymous `SDM` refers to the Super Droplet Method -- a
   Monte-Carlo algorithm introduced in @Shima_et_al_2009 to represent the coagulation
   of droplets in modelling frameworks such as Large-Eddy Simulations (LES) of atmospheric
   flows. 
+Recent efforts have culminated
+  in a second release, which includes a variety of new processes for both liquid and ice-phase particles,
+  performance enhancements such as adaptive time-stepping, as well as a broadened suite of 
+  examples which demonstrate, test, and motivate the use of the SDM for cloud modeling research.
+
+
+# Background and Statement of Need
 The key motivation behind development of `PySDM` has been to offer the community an approachable
   readily reusable software for users and developers who wish to contribute to the
   scientific progress of particle-based methods for simulating atmospheric clouds.
@@ -78,10 +85,6 @@ A user of the package can select top-level options such as the simulation
   processes: condensational growth/evaporation, collisional growth,
   aqueous sulphur chemistry, as well as coupling of particle transport
   and vapour/heat budget with grid-discretised fluid flow.
-Recent efforts have culminated
-  in a second release, which includes a variety of new processes for both liquid and ice-phase particles,
-  performance enhancements such as adaptive time-stepping, as well as a broadened suite of 
-  examples which demonstrate, test, and motivate the use of the SDM for cloud modeling research.
 This paper outlines these subsequent developments in the "v2" releases of `PySDM`
   including three new processes (collisional breakup, immersion freezing, and surface-partitioning of organic aerosol components), 
   initialisation framework for aerosol size and composition,

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -20,7 +20,7 @@ authors:
     orcid: 0000-0002-5310-4554
   - name: Sajjad Azimi
     affiliation: "3"
-    orcid: TODO
+    orcid: 0000-0002-6329-7775
   - name: Piotr Bartman
     orcid: 0000-0003-0265-6428
     affiliation: "2"


### PR DESCRIPTION
We are still at around 1500+ words, not including code snippets, compared with the requested 250-1000 words for a JOSS publication. I have reduced the intro/background significantly to avoid repeating information already contained elsewhere (such as in JOSS v1), and to remove more esoteric scientific aspects not relevant to a software paper. 

@slayoo this includes the discussion of moving spectral methods, which have a better place in a scientific publication, as well as some details about the immersion freezing literature. 
@slayoo Perhaps there is further room to make the adaptivity section more concise?

@claresinger I would appreciate if you can reduce the aerosol sections to focus mainly on the novel initialisation implementation/snippet to show the API, and a reference to the relevant PySDM-examples and a mention of the results that they reproduce/aim to show.

How does this sound? Recommendations on the breakup section/general are welcomed!