### PR TITLE
Ej/frag fixes

### DIFF
--- a/PySDM/backends/impl_numba/methods/collisions_methods.py
+++ b/PySDM/backends/impl_numba/methods/collisions_methods.py
@@ -107,8 +107,9 @@ def break_up(  # pylint: disable=too-many-arguments
                 attributes[a, k] /= tmp2
                 attributes[a, j] = attributes[a, k]
 
-        if overflow_flag and warn_overflows:
-            warn("overflow", __file__)
+        if overflow_flag:
+            if warn_overflows:
+                warn("overflow", __file__)
             break
 
         atomic_add(breakup_rate, cid, gamma_tmp * multiplicity[k])

--- a/PySDM/backends/impl_numba/methods/collisions_methods.py
+++ b/PySDM/backends/impl_numba/methods/collisions_methods.py
@@ -61,6 +61,7 @@ def break_up(  # pylint: disable=too-many-arguments
     max_multiplicity,
     breakup_rate,
     breakup_rate_deficit,
+    warn_overflows,
 ):  # pylint: disable=too-many-branches
     gamma_tmp = 0
     gamma_deficit = gamma[i]
@@ -106,7 +107,7 @@ def break_up(  # pylint: disable=too-many-arguments
                 attributes[a, k] /= tmp2
                 attributes[a, j] = attributes[a, k]
 
-        if overflow_flag:
+        if overflow_flag and warn_overflows:
             warn("overflow", __file__)
             break
 
@@ -278,6 +279,7 @@ class CollisionsMethods(BackendMethods):
         breakup_rate_deficit,
         is_first_in_pair,
         max_multiplicity,
+        warn_overflows,
     ):
         # pylint: disable=not-an-iterable,too-many-nested-blocks
         for i in numba.prange(length // 2):
@@ -312,6 +314,7 @@ class CollisionsMethods(BackendMethods):
                     max_multiplicity,
                     breakup_rate,
                     breakup_rate_deficit,
+                    warn_overflows,
                 )
             flag_zero_multiplicity(j, k, multiplicity, healthy)
 
@@ -332,6 +335,7 @@ class CollisionsMethods(BackendMethods):
         breakup_rate,
         breakup_rate_deficit,
         is_first_in_pair,
+        warn_overflows,
     ):
         max_multiplicity = np.iinfo(multiplicity.data.dtype).max // 2e5
         self.__collision_coalescence_breakup_body(
@@ -351,6 +355,7 @@ class CollisionsMethods(BackendMethods):
             breakup_rate_deficit=breakup_rate_deficit.data,
             is_first_in_pair=is_first_in_pair.indicator.data,
             max_multiplicity=max_multiplicity,
+            warn_overflows=warn_overflows,
         )
 
     @staticmethod

--- a/PySDM/dynamics/collisions/collision.py
+++ b/PySDM/dynamics/collisions/collision.py
@@ -41,6 +41,7 @@ class Collision:
         adaptive: bool = True,
         dt_coal_range=DEFAULTS.dt_coal_range,
         enable_breakup: bool = True,
+        warn_overflows: bool = True,
     ):
         assert substeps == 1 or adaptive is False
 
@@ -48,6 +49,7 @@ class Collision:
 
         self.enable = True
         self.enable_breakup = enable_breakup
+        self.warn_overflows = warn_overflows
 
         self.collision_kernel = collision_kernel
         self.compute_coalescence_efficiency = coalescence_efficiency
@@ -202,6 +204,7 @@ class Collision:
             breakup_rate=self.breakup_rate,
             breakup_rate_deficit=self.breakup_rate_deficit,
             is_first_in_pair=self.is_first_in_pair,
+            warn_overflows=self.warn_overflows,
         )
 
         if self.adaptive:

--- a/PySDM/particulator.py
+++ b/PySDM/particulator.py
@@ -143,6 +143,7 @@ class Particulator:  # pylint: disable=too-many-public-methods
         breakup_rate,
         breakup_rate_deficit,
         is_first_in_pair,
+        warn_overflows,
     ):
         idx = self.attributes._ParticleAttributes__idx
         healthy = self.attributes._ParticleAttributes__healthy_memory
@@ -165,6 +166,7 @@ class Particulator:  # pylint: disable=too-many-public-methods
                 breakup_rate=breakup_rate,
                 breakup_rate_deficit=breakup_rate_deficit,
                 is_first_in_pair=is_first_in_pair,
+                warn_overflows=warn_overflows,
             )
         else:
             self.backend.collision_coalescence(

--- a/PySDM/products/collision/collision_rates.py
+++ b/PySDM/products/collision/collision_rates.py
@@ -20,17 +20,31 @@ class CollisionRatePerGridbox(RateProduct):
         )
 
 
-class CoalescenceRatePerGridbox(RateProduct):
+class CoalescenceOnlyRatePerGridbox(RateProduct):
     def __init__(self, name=None, unit="s^-1"):
         super().__init__(
             name=name, unit=unit, counter="coalescence_rate", dynamic="Coalescence"
         )
 
 
-class BreakupRatePerGridbox(RateProduct):
+class CoalescenceRatePerGridbox(RateProduct):
+    def __init__(self, name=None, unit="s^-1"):
+        super().__init__(
+            name=name, unit=unit, counter="coalescence_rate", dynamic="Collision"
+        )
+
+
+class BreakupOnlyRatePerGridbox(RateProduct):
     def __init__(self, name=None, unit="s^-1"):
         super().__init__(
             name=name, unit=unit, counter="breakup_rate", dynamic="Breakup"
+        )
+
+
+class BreakupRatePerGridbox(RateProduct):
+    def __init__(self, name=None, unit="s^-1"):
+        super().__init__(
+            name=name, unit=unit, counter="breakup_rate", dynamic="Collision"
         )
 
 

--- a/tests/unit_tests/dynamics/collisions/test_sdm_breakup.py
+++ b/tests/unit_tests/dynamics/collisions/test_sdm_breakup.py
@@ -101,6 +101,7 @@ class TestSDMBreakup:
             breakup_rate=general_zeros,
             breakup_rate_deficit=general_zeros,
             is_first_in_pair=is_first_in_pair,
+            warn_overflows=True,
         )
 
         # Assert
@@ -188,6 +189,7 @@ class TestSDMBreakup:
             breakup_rate=breakup_rate,
             breakup_rate_deficit=general_zeros,
             is_first_in_pair=is_first_in_pair,
+            warn_overflows=True,
         )
 
         # Assert
@@ -286,6 +288,7 @@ class TestSDMBreakup:
             breakup_rate=breakup_rate,
             breakup_rate_deficit=breakup_rate_deficit,
             is_first_in_pair=is_first_in_pair,
+            warn_overflows=True,
         )
 
         # Assert
@@ -363,6 +366,7 @@ class TestSDMBreakup:
             breakup_rate=breakup_rate,
             breakup_rate_deficit=breakup_rate_deficit,
             is_first_in_pair=is_first_in_pair,
+            warn_overflows=True,
         )
         assert breakup_rate_deficit[0] > 0
         np.testing.assert_equal(
@@ -454,6 +458,7 @@ class TestSDMBreakup:
             breakup_rate=breakup_rate,
             breakup_rate_deficit=breakup_rate_deficit,
             is_first_in_pair=is_first_in_pair,
+            warn_overflows=True,
         )
 
         # Assert

--- a/tests/unit_tests/dynamics/collisions/test_sdm_breakup.py
+++ b/tests/unit_tests/dynamics/collisions/test_sdm_breakup.py
@@ -1,12 +1,9 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
-from itertools import product
-
 import numpy as np
 import pytest
 
 import PySDM.physics.constants as const
-from PySDM import Builder, particulator
-from PySDM.attributes.impl import attribute
+from PySDM import Builder
 from PySDM.backends import CPU
 from PySDM.backends.impl_common.pair_indicator import make_PairIndicator
 from PySDM.dynamics import Breakup


### PR DESCRIPTION
Adds the following breakup-related features:

- keyword argument to print overflow warnings during collision step
- additional rate-products specific to the breakup, collision, or coalescence dynamics
- new breakup unit test with larger n_sd and full dynamics to check for underflow