### PR TITLE
add support for vectorizing formulae (using either np.vectorize or numba.vectorize)

### DIFF
--- a/PySDM/formulae.py
+++ b/PySDM/formulae.py
@@ -4,6 +4,7 @@ Logic for enabling common CPU/GPU physics formulae code
 import inspect
 import numbers
 import re
+import warnings
 from collections import namedtuple
 from functools import lru_cache, partial
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ from typing import Optional
 import numba
 import numpy as np
 import pint
+from numba.core.errors import NumbaExperimentalFeatureWarning
 
 from PySDM import physics
 from PySDM.backends.impl_numba import conf
@@ -203,7 +205,9 @@ def _formula(func, constants, dimensional_analysis, **kw):
                 },
             )
         )
-        return vectorizer(function)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=NumbaExperimentalFeatureWarning)
+            return vectorizer(function)
     return numba.njit(
         getattr(loc["_"], func.__name__),
         **{

--- a/PySDM/formulae.py
+++ b/PySDM/formulae.py
@@ -163,9 +163,12 @@ class Formulae:  # pylint: disable=too-few-public-methods,too-many-instance-attr
 
 
 def _formula(func, constants, dimensional_analysis, **kw):
+    parameters_keys = tuple(inspect.signature(func).parameters.keys())
+    special_params = ("_", "const")
+
     if dimensional_analysis:
-        first_param = tuple(inspect.signature(func).parameters.keys())[0]
-        if first_param in ("_", "const"):
+        first_param = parameters_keys[0]
+        if first_param in special_params:
             return partial(func, constants)
         return func
 
@@ -173,7 +176,7 @@ def _formula(func, constants, dimensional_analysis, **kw):
     for line in inspect.getsourcelines(func)[0]:
         source += f"{line}\n"
     loc = {}
-    for arg_name in ("_", "const"):
+    for arg_name in special_params:
         source = source.replace(
             f"def {func.__name__}({arg_name},", f"def {func.__name__}("
         )
@@ -182,6 +185,25 @@ def _formula(func, constants, dimensional_analysis, **kw):
     exec(  # pylint:disable=exec-used
         source, {"const": constants, "np": np, **extras}, loc
     )
+
+    n_params = len(parameters_keys) - (1 if parameters_keys[0] in special_params else 0)
+    function = getattr(loc["_"], func.__name__)
+    if hasattr(func, "__vectorize"):
+        vectorizer = (
+            np.vectorize
+            if numba.config.DISABLE_JIT  # pylint: disable=no-member
+            else numba.vectorize(
+                "float64(" + ",".join(["float64"] * n_params) + ")",
+                target="cpu",
+                nopython=True,
+                **{
+                    k: v
+                    for k, v in conf.JIT_FLAGS.items()
+                    if k not in ("parallel", "error_model")
+                },
+            )
+        )
+        return vectorizer(function)
     return numba.njit(
         getattr(loc["_"], func.__name__),
         **{

--- a/PySDM/physics/surface_tension/compressed_film_ruehl.py
+++ b/PySDM/physics/surface_tension/compressed_film_ruehl.py
@@ -95,3 +95,4 @@ CompressedFilmRuehl.sigma.__extras = {
     "minfun": minfun,
     "within_tolerance": within_tolerance,
 }
+CompressedFilmRuehl.sigma.__vectorize = True

--- a/PySDM/physics/surface_tension/szyszkowski_langmuir.py
+++ b/PySDM/physics/surface_tension/szyszkowski_langmuir.py
@@ -58,5 +58,8 @@ class SzyszkowskiLangmuir:  # pylint: disable=too-few-public-methods
             ) * np.log(1 + Cb_iso * (1 - f_surf) / const.RUEHL_C0)
 
         # surface tension bounded between sgm_min and sgm_w
-        sgm = np.minimum(np.maximum(sgm, const.RUEHL_sgm_min), const.sgm_w)
+        sgm = min(max(sgm, const.RUEHL_sgm_min), const.sgm_w)
         return sgm
+
+
+SzyszkowskiLangmuir.sigma.__vectorize = True

--- a/tests/smoke_tests/lowe_et_al_2019/test_surface_tension_models.py
+++ b/tests/smoke_tests/lowe_et_al_2019/test_surface_tension_models.py
@@ -40,7 +40,7 @@ class TestFig1:
         )
 
         # act
-        sigma = formulae.surface_tension.sigma.py_func(
+        sigma = formulae.surface_tension.sigma(
             np.nan, V_WET, V_DRY, aer.modes[0]["f_org"]
         )
 
@@ -166,11 +166,9 @@ class TestFig1:
         )
 
         # act
-        sigma = np.zeros(len(V_WET))
-        for i, vw in enumerate(V_WET):
-            sigma[i] = formulae.surface_tension.sigma.py_func(
-                TEMPERATURE, vw, V_DRY, aer.modes[0]["f_org"]
-            )
+        sigma = formulae.surface_tension.sigma(
+            TEMPERATURE, V_WET, V_DRY, aer.modes[0]["f_org"]
+        )
 
         # assert
         test = np.array(
@@ -293,7 +291,7 @@ class TestFig1:
         )
 
         # act
-        sigma = formulae.surface_tension.sigma.py_func(
+        sigma = formulae.surface_tension.sigma(
             TEMPERATURE, V_WET, V_DRY, aer.modes[0]["f_org"]
         )
 

--- a/tests/unit_tests/test_formulae.py
+++ b/tests/unit_tests/test_formulae.py
@@ -1,19 +1,64 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+import warnings
+
+import numpy as np
+import pytest
+from numba.core.errors import NumbaExperimentalFeatureWarning
+
 from PySDM import formulae
+from PySDM.physics import si
 
 
-def test_c_inline():
-    # arrange
-    def fun(_, xxx):
-        return min(
-            xxx,
-            2,
-        )
+class TestFormulae:
+    @staticmethod
+    def test_c_inline():
+        # arrange
+        def fun(_, xxx):
+            return min(
+                xxx,
+                2,
+            )
 
-    # act
-    c_code = formulae._c_inline(
-        fun, constants={"pi": 3.14}, xxx=0
-    )  # pylint: disable=protected-access
+        # act
+        c_code = formulae._c_inline(
+            fun, constants={"pi": 3.14}, xxx=0
+        )  # pylint: disable=protected-access
 
-    # assert
-    assert ", )" not in c_code
+        # assert
+        assert ", )" not in c_code
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "formulae_init_args",
+        (
+            {"surface_tension": "Constant"},
+            {
+                "surface_tension": "CompressedFilmOvadnevaite",
+                "constants": {"sgm_org": 40 * si.mN / si.m, "delta_min": 0.1 * si.nm},
+            },
+            {
+                "surface_tension": "CompressedFilmRuehl",
+                "constants": {
+                    "RUEHL_nu_org": 1e2 * si.cm**3 / si.mole,
+                    "RUEHL_A0": 115e-20 * si.m * si.m,
+                    "RUEHL_C0": 6e-7,
+                    "RUEHL_m_sigma": 0.3e17 * si.J / si.m**2,
+                    "RUEHL_sgm_min": 40.0 * si.mN / si.m,
+                },
+            },
+        ),
+    )
+    @pytest.mark.parametrize("T", (300.0, np.array([300, 301])))
+    @pytest.mark.parametrize("v_wet", (1e-8**3.0, np.array([1e-8**3, 2e-8**3])))
+    @pytest.mark.parametrize("v_dry", (1e-9**3.0, np.array([1e-9**3, 2e-9**3])))
+    @pytest.mark.parametrize("f_org", (0.5, np.array([1.0, 0.5])))
+    def test_trickier_formula_vectorised(formulae_init_args, T, v_wet, v_dry, f_org):
+        # arrange
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=NumbaExperimentalFeatureWarning)
+            sut = formulae.Formulae(**formulae_init_args).surface_tension.sigma
+
+        # act
+        sut(T, v_wet, v_dry, f_org)
+
+        # assert

--- a/tests/unit_tests/test_formulae.py
+++ b/tests/unit_tests/test_formulae.py
@@ -1,9 +1,6 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
-import warnings
-
 import numpy as np
 import pytest
-from numba.core.errors import NumbaExperimentalFeatureWarning
 
 from PySDM import formulae
 from PySDM.physics import si
@@ -54,9 +51,7 @@ class TestFormulae:
     @pytest.mark.parametrize("f_org", (0.5, np.array([1.0, 0.5])))
     def test_trickier_formula_vectorised(formulae_init_args, T, v_wet, v_dry, f_org):
         # arrange
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=NumbaExperimentalFeatureWarning)
-            sut = formulae.Formulae(**formulae_init_args).surface_tension.sigma
+        sut = formulae.Formulae(**formulae_init_args).surface_tension.sigma
 
         # act
         sut(T, v_wet, v_dry, f_org)


### PR DESCRIPTION
CC @claresinger
Includes a unit test in which Ruehl surface tension `sigma` is tested with different combinations of scalar- and vector-valued arguments - please confirm if this makes #904 obsolete?