### PR TITLE
making it possible to call `Builder::request_attribute` before `Builder::build` for attributes that depend on formulae

### DIFF
--- a/PySDM/attributes/impl/mapper.py
+++ b/PySDM/attributes/impl/mapper.py
@@ -36,64 +36,58 @@ from PySDM.dynamics.impl.chemistry_utils import AQUEOUS_COMPOUNDS
 from PySDM.physics.surface_tension import Constant
 
 attributes = {
-    "n": lambda _: Multiplicities,
-    "volume": lambda _: Volume,
-    "dry volume organic": lambda dynamics: (
+    "n": lambda _, __: Multiplicities,
+    "volume": lambda _, __: Volume,
+    "dry volume organic": lambda dynamics, formulae: (
         make_dummy_attribute_factory("dry volume organic")
         if "Condensation" in dynamics
-        and (
-            dynamics["Condensation"].particulator.formulae.surface_tension.__name__
-            == Constant.__name__
-        )
+        and formulae.surface_tension.__name__ == Constant.__name__
         else DryVolumeOrganic
     ),
-    "dry volume": lambda dynamics: DryVolumeDynamic
+    "dry volume": lambda dynamics, formulae: DryVolumeDynamic
     if "AqueousChemistry" in dynamics
     else DryVolume,
-    "dry volume organic fraction": lambda dynamics: (
+    "dry volume organic fraction": lambda dynamics, formulae: (
         make_dummy_attribute_factory("dry volume organic fraction")
         if "Condensation" in dynamics
-        and (
-            dynamics["Condensation"].particulator.formulae.surface_tension.__name__
-            == Constant.__name__
-        )
+        and formulae.surface_tension.__name__ == Constant.__name__
         else OrganicFraction
     ),
-    "kappa times dry volume": lambda _: KappaTimesDryVolume,
-    "kappa": lambda _: Kappa,
-    "radius": lambda _: Radius,
-    "area": lambda _: Area,
-    "dry radius": lambda _: DryRadius,
-    "terminal velocity": lambda _: TerminalVelocity,
-    "cell id": lambda _: CellID,
-    "cell origin": lambda _: CellOrigin,
-    "cooling rate": lambda _: CoolingRate,
-    "position in cell": lambda _: PositionInCell,
-    "temperature": lambda _: Temperature,
-    "heat": lambda _: Heat,
-    "critical volume": lambda _: CriticalVolume,
+    "kappa times dry volume": lambda _, __: KappaTimesDryVolume,
+    "kappa": lambda _, __: Kappa,
+    "radius": lambda _, __: Radius,
+    "area": lambda _, __: Area,
+    "dry radius": lambda _, __: DryRadius,
+    "terminal velocity": lambda _, __: TerminalVelocity,
+    "cell id": lambda _, __: CellID,
+    "cell origin": lambda _, __: CellOrigin,
+    "cooling rate": lambda _, __: CoolingRate,
+    "position in cell": lambda _, __: PositionInCell,
+    "temperature": lambda _, __: Temperature,
+    "heat": lambda _, __: Heat,
+    "critical volume": lambda _, __: CriticalVolume,
     **{
         "moles_"
-        + compound: partial(lambda _, c: make_mole_amount_factory(c), c=compound)
+        + compound: partial(lambda _, __, c: make_mole_amount_factory(c), c=compound)
         for compound in AQUEOUS_COMPOUNDS
     },
     **{
         "conc_"
-        + compound: partial(lambda _, c: make_concentration_factory(c), c=compound)
+        + compound: partial(lambda _, __, c: make_concentration_factory(c), c=compound)
         for compound in AQUEOUS_COMPOUNDS
     },
-    "pH": lambda _: Acidity,
-    "conc_H": lambda _: HydrogenIonConcentration,
-    "freezing temperature": lambda _: FreezingTemperature,
-    "immersed surface area": lambda _: ImmersedSurfaceArea,
-    "critical supersaturation": lambda _: CriticalSupersaturation,
-    "wet to critical volume ratio": lambda _: WetToCriticalVolumeRatio,
+    "pH": lambda _, __: Acidity,
+    "conc_H": lambda _, __: HydrogenIonConcentration,
+    "freezing temperature": lambda _, __: FreezingTemperature,
+    "immersed surface area": lambda _, __: ImmersedSurfaceArea,
+    "critical supersaturation": lambda _, __: CriticalSupersaturation,
+    "wet to critical volume ratio": lambda _, __: WetToCriticalVolumeRatio,
 }
 
 
-def get_class(name, dynamics):
+def get_class(name, dynamics, formulae):
     if name not in attributes:
         raise ValueError(
             f"Unknown attribute name: {name}; valid names: {', '.join(attributes)}"
         )
-    return attributes[name](dynamics)
+    return attributes[name](dynamics, formulae)

--- a/PySDM/builder.py
+++ b/PySDM/builder.py
@@ -59,7 +59,7 @@ class Builder:
     def request_attribute(self, attribute, variant=None):
         if attribute not in self.req_attr:
             self.req_attr[attribute] = attr_class(
-                attribute, self.particulator.dynamics
+                attribute, self.particulator.dynamics, self.formulae
             )(self)
         if variant is not None:
             assert variant == self.req_attr[attribute]

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -1,0 +1,45 @@
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+import numpy as np
+
+from PySDM import Builder
+from PySDM.backends import CPU
+from PySDM.dynamics import Condensation
+from PySDM.environments import Box
+
+
+class TestBuilder:
+    @staticmethod
+    def test_build_minimal():
+        # arrange
+        builder = Builder(backend=CPU(), n_sd=1)
+        builder.set_environment(Box(dt=np.nan, dv=np.nan))
+
+        # act
+        particulator = builder.build(
+            products=(), attributes={k: np.asarray([0]) for k in ("n", "volume")}
+        )
+
+        # assert
+        _ = particulator.attributes
+
+    @staticmethod
+    def test_request_attribute():
+        # arrange
+        env = Box(dt=-1, dv=np.nan)
+        builder = Builder(backend=CPU(), n_sd=1)
+        builder.set_environment(env)
+        builder.add_dynamic(Condensation())
+
+        # act
+        builder.request_attribute("critical supersaturation")
+
+        # assert
+        particulator = builder.build(
+            products=(),
+            attributes={
+                k: np.asarray([0])
+                for k in ("n", "volume", "dry volume", "kappa times dry volume")
+            },
+        )
+        env["T"] = np.nan
+        _ = particulator.attributes["critical supersaturation"].to_ndarray()

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -37,7 +37,7 @@ class TestBuilder:
         particulator = builder.build(
             products=(),
             attributes={
-                k: np.asarray([0])
+                k: np.asarray([1])
                 for k in ("n", "volume", "dry volume", "kappa times dry volume")
             },
         )


### PR DESCRIPTION
Closes #751.
Will allow to remove the `Magick` class from ARG example (https://github.com/atmos-cloud-sim-uj/PySDM-examples/blob/5fa951a9982d17b9d1aa15b16ed3a2075eb6ac09/PySDM_examples/Abdul_Razzak_Ghan_2000/run_ARG_parcel.py#L17)