### PR TITLE
Ej/builder remove dynamic

### DIFF
--- a/PySDM/backends/impl_numba/methods/collisions_methods.py
+++ b/PySDM/backends/impl_numba/methods/collisions_methods.py
@@ -251,7 +251,7 @@ def straub_p1(  # pylint: disable=too-many-arguments,unused-argument
     rand,
 ):
     E_D1 = 0.04 * CM
-    delD1 = 0.125 * CW[i] ** (1 / 2)
+    delD1 = 0.0125 * CW[i] ** (1 / 2)
     var_1 = delD1**2 / 12
     sigma1 = np.sqrt(np.log(var_1 / E_D1**2 + 1))
     mu1 = np.log(E_D1) - sigma1**2 / 2
@@ -272,7 +272,7 @@ def straub_p2(  # pylint: disable=too-many-arguments,unused-argument
     rand,
 ):
     mu2 = 0.095 * CM
-    delD2 = 0.22 * (CW[i] - 21.0)
+    delD2 = 0.007 * (CW[i] - 21.0)
     sigma2 = delD2**2 / 12
     X = rand[i]
 
@@ -291,7 +291,7 @@ def straub_p3(  # pylint: disable=too-many-arguments,unused-argument
     rand,
 ):
     mu3 = 0.9 * ds[i]
-    delD3 = 0.01 * (0.76 * CW[i] ** 1 / 2 + 1.0)
+    delD3 = 0.01 * (0.76 * CW[i] ** (1 / 2) + 1.0)
     sigma3 = delD3**2 / 12
     X = rand[i]
 
@@ -306,12 +306,12 @@ def straub_p4(  # pylint: disable=too-many-arguments,unused-argument,too-many-lo
     i, CW, ds, v_max, frag_size, Nr1, Nr2, Nr3
 ):
     E_D1 = 0.04 * CM
-    delD1 = 0.125 * CW[i] ** (1 / 2)
+    delD1 = 0.0125 * CW[i] ** (1 / 2)
     var_1 = delD1**2 / 12
     sigma1 = np.sqrt(np.log(var_1 / E_D1**2 + 1))
     mu1 = np.log(E_D1) - sigma1**2 / 2
     mu2 = 0.095 * CM
-    delD2 = 0.22 * (CW[i] - 21.0)
+    delD2 = 0.007 * (CW[i] - 21.0)
     sigma2 = delD2**2 / 12
     mu3 = 0.9 * ds[i]
     delD3 = 0.01 * (0.76 * CW[i] ** 1 / 2 + 1.0)

--- a/PySDM/builder.py
+++ b/PySDM/builder.py
@@ -45,6 +45,12 @@ class Builder:
         assert key not in self.particulator.dynamics
         self.particulator.dynamics[key] = dynamic
 
+    def remove_dynamic(self, dynamic):
+        assert self.particulator.environment is not None
+        key = inspect.getmro(type(dynamic))[-2].__name__
+        assert key in self.particulator.dynamics
+        self.particulator.dynamics.pop(key)
+
     def register_product(self, product, buffer):
         if product.name in self.particulator.products:
             raise Exception(f'product name "{product.name}" already registered')


### PR DESCRIPTION
Add option to remove a dynamic from builder; accommodates inheritance in edj PySDM_example