### PR TITLE
add pylint check for max file length

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Analysing the code with pylint
       run: |
         # TODO #682
-        pylint --unsafe-load-any-extension=y --disable=fixme,invalid-name,missing-function-docstring,missing-class-docstring,protected-access,duplicate-code $(git ls-files '*.py')
+        pylint --max-module-lines=800 --unsafe-load-any-extension=y --disable=fixme,invalid-name,missing-function-docstring,missing-class-docstring,protected-access,duplicate-code $(git ls-files '*.py')
 
   build:
     needs: [pylint, pdoc, codecov, precommit]


### PR DESCRIPTION
Would be great to soon reduce this limit to something like 500, currently these three are longer:
- PySDM/backends/impl_numba/methods/condensation_methods.py:4:0: C0302: Too many lines in module (715/400) (too-many-lines)
- PySDM/backends/impl_thrust_rtc/methods/collisions_methods.py:4:0: C0302: Too many lines in module (770/400) (too-many-lines)
- tests/unit_tests/dynamics/collisions/test_sdm_breakup.py:4:0: C0302: Too many lines in module (787/400) (too-many-lines)
